### PR TITLE
Make DeviceError picklable.

### DIFF
--- a/ftd2xx/ftd2xx.py
+++ b/ftd2xx/ftd2xx.py
@@ -41,6 +41,9 @@ class DeviceError(Exception):
 
     def __str__(self):
         return self.message
+        
+    def __reduce__(self):
+        return type(self), (self.message,)
 
 
 class DeviceInfoDetail(TypedDict):

--- a/ftd2xx/ftd2xx.py
+++ b/ftd2xx/ftd2xx.py
@@ -4,6 +4,7 @@ _pythonic_ way. For full documentation please refer to the FTDI
 Programming Guide. This module is based on Pablo Bleyers d2xx module,
 except this uses ctypes instead of an extension approach.
 """
+
 from __future__ import annotations
 
 import ctypes as c
@@ -41,7 +42,7 @@ class DeviceError(Exception):
 
     def __str__(self):
         return self.message
-        
+
     def __reduce__(self):
         return type(self), (self.message,)
 


### PR DESCRIPTION
I am using multiprocessing to seperate my hardware logic from UI and thus had issues trying to pickle DeviceError's trying to report problems back to the UI process. Found it was because of [this issue](https://stackoverflow.com/a/49715949/1111886) and was able to write a fix easily. 